### PR TITLE
size of package for arduino board manager correction

### DIFF
--- a/Software and Installation/IDE files/package_GlowDuino_index.json
+++ b/Software and Installation/IDE files/package_GlowDuino_index.json
@@ -41,7 +41,7 @@
                         "online": "https://www.github.com/GlowDuino/GlowDuino"
                     },
                     "name": "GlowDuino Boards",
-                    "size": "35806",
+                    "size": "34982",
                     "toolsDependencies": [],
                     "url": "https://github.com/GlowDuino/GlowDuino/blob/main/Software%20and%20Installation/IDE%20files/GlowDuino2.0.2.zip?raw=true",
                     "version": "2.0.2"


### PR DESCRIPTION
corrected the package index .json to reflect the correct size of the 2.0.2 board installation payload.